### PR TITLE
Update to better handle non-ASCII names

### DIFF
--- a/Exporter.py
+++ b/Exporter.py
@@ -175,7 +175,6 @@ def sanitize_filename(name: str) -> str:
     hash = hashlib.sha256(name.encode()).hexdigest()[:8]
     return f'{with_replacement}_{hash}'
 
-
 def set_mtime(path: Path, time: int):
     """utime wants to set atime and mtime, we just set it the same"""
     os.utime(path, (time, time))

--- a/Exporter.py
+++ b/Exporter.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 import itertools
 import json
 import os
-import urllib.parse
 
 # If you have a bunch of files already existing and really want the files' date-modified attr
 # to be correct but don't want to rerun an export, you can change this to True for a single run, then
@@ -169,17 +168,13 @@ def sanitize_filename(name: str) -> str:
     # this list of characters is just from trying to rename a file in Explorer (on Windows)
     # I think the actual requirements are per fileystem and will be different on Mac
     # I'm not sure how other unicode chars are handled
-    try:
-        with_replacement = re.sub(r'[:\\/*?<>|"]', ' ', name)
-        if name == with_replacement:
-            return name
-        log(f'filename `{name}` contained bad chars, replacing by `{with_replacement}`')
-        hash = hashlib.sha256(name.encode()).hexdigest()[:8]
-        return f'{with_replacement}_{hash}'
-    except UnicodeEncodeError:
-        encoded_name = urllib.parse.quote(name.encode())
-        log(f'filename `{name}` cannot be handled, trying with url encoding `{encoded_name}`')
-        return encoded_name
+    with_replacement = re.sub(r'[:\\/*?<>|"]', ' ', name)
+    if name == with_replacement:
+        return name
+    log(f'filename `{name}` contained bad chars, replacing by `{with_replacement}`')
+    hash = hashlib.sha256(name.encode()).hexdigest()[:8]
+    return f'{with_replacement}_{hash}'
+
 
 def set_mtime(path: Path, time: int):
     """utime wants to set atime and mtime, we just set it the same"""

--- a/Exporter.py
+++ b/Exporter.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 import itertools
 import json
 import os
+import urllib.parse
 
 # If you have a bunch of files already existing and really want the files' date-modified attr
 # to be correct but don't want to rerun an export, you can change this to True for a single run, then
@@ -38,7 +39,7 @@ def init_directory(name):
 def init_logging(directory):
     global log_file, log_fh
     log_file = directory / '{:%Y_%m_%d_%H_%M}.txt'.format(datetime.now())
-    log_fh = open(log_file, 'w')
+    log_fh = open(log_file, 'w', encoding="utf-8")
 
 class Format(Enum):
     F3D = 'f3d'
@@ -168,12 +169,17 @@ def sanitize_filename(name: str) -> str:
     # this list of characters is just from trying to rename a file in Explorer (on Windows)
     # I think the actual requirements are per fileystem and will be different on Mac
     # I'm not sure how other unicode chars are handled
-    with_replacement = re.sub(r'[:\\/*?<>|"]', ' ', name)
-    if name == with_replacement:
-        return name
-    log(f'filename `{name}` contained bad chars, replacing by `{with_replacement}`')
-    hash = hashlib.sha256(name.encode()).hexdigest()[:8]
-    return f'{with_replacement}_{hash}'
+    try:
+        with_replacement = re.sub(r'[:\\/*?<>|"]', ' ', name)
+        if name == with_replacement:
+            return name
+        log(f'filename `{name}` contained bad chars, replacing by `{with_replacement}`')
+        hash = hashlib.sha256(name.encode()).hexdigest()[:8]
+        return f'{with_replacement}_{hash}'
+    except UnicodeEncodeError:
+        encoded_name = urllib.parse.quote(name.encode())
+        log(f'filename `{name}` cannot be handled, trying with url encoding `{encoded_name}`')
+        return encoded_name
 
 def set_mtime(path: Path, time: int):
     """utime wants to set atime and mtime, we just set it the same"""


### PR DESCRIPTION
This fixes a problem with `init_logging()` which didn't open the log file for utf-8 encoding, and thus `visit_file()` raised an error when writing non-ASCII names to the log.

This seems to have fixed a problem I had with some Chinese characters in imported files (STEP & DWG), and they now export correctly as f3d/step (and their sketches as dxf) with the original names.  Tested under Windows 10, and saving to a Linux NAS.

An example part name was `小板3D` which apparently translates to "Small Board 3D".

I also added code to handle a `UnicodeEncodeError `in `sanitize_filename()` with a fallback of URL encoding the name (e.g. `%41%42%43`), but this may not be needed.  It could also make filenames that are too long.  I don't think this code ever code executed once I determined the correct fix above, so it is untested.  If this is left out, then the merge can be reduced to only one line as the import of `urllib.parse` is not needed.