### PR TITLE
Export files with spaces instead of _ for versions and support compressed files

### DIFF
--- a/Exporter.py
+++ b/Exporter.py
@@ -229,7 +229,7 @@ def export_file(ctx: Ctx, format: Format, doc: LazyDocument) -> Counter:
         log(f'{output_path} already exists, skipping')
         return Counter(skipped=1)
     for archive_extension in archive_extensions:
-        archive_path = export_archive_filename(ctx, format, archive_extension, file)
+        archive_path = export_archive_filename(ctx, format, archive_extension, doc.file)
         if archive_path.exists():
             log(f'{output_path} already exists as archive, skipping')
             return Counter(skipped=1)

--- a/Exporter.py
+++ b/Exporter.py
@@ -18,7 +18,7 @@ import os
 update_existing_file_times = False
 
 # Older versions of this script used '_' as seperator but Fusion 360 uses ' ' per default in manual exports.
-VERSION_SEPARATOR = '_' # use either ' ' or '_'
+VERSION_SEPARATOR = ' ' # use either ' ' or '_'
 
 log_file = None
 log_fh = None

--- a/Exporter.py
+++ b/Exporter.py
@@ -47,6 +47,8 @@ FormatFromName = {x.value: x for x in Format}
 
 DEFAULT_SELECTED_FORMATS = {Format.F3D, Format.STEP}
 
+archive_extensions = ['zip', 'gz', 'tar.gz', 'tar.bz2', 'tar.xz']
+
 class Ctx(NamedTuple):
     app: adsk.core.Application
     folder: Path
@@ -165,7 +167,12 @@ def sanitize_filename(name: str) -> str:
 
 def export_filename(ctx: Ctx, format: Format, file):
     sanitized = sanitize_filename(file.name)
-    name = f'{sanitized}_v{file.versionNumber}.{format.value}'
+    name = f'{sanitized} v{file.versionNumber}.{format.value}'
+    return ctx.folder / name
+
+def export_archive_filename(ctx: Ctx, format: Format, archive_extension, file):
+    sanitized = sanitize_filename(file.name)
+    name = f'{sanitized} v{file.versionNumber}.{format.value}.{archive_extension}'
     return ctx.folder / name
 
 def export_sketches(ctx, component):
@@ -195,6 +202,11 @@ def export_file(ctx: Ctx, format: Format, file, doc: LazyDocument) -> Counter:
     if output_path.exists():
         log(f'{output_path} already exists, skipping')
         return Counter(skipped=1)
+    for archive_extension in archive_extensions:
+        archive_path = export_archive_filename(ctx, format, archive_extension, file)
+        if archive_path.exists():
+            log(f'{output_path} already exists as archive, skipping')
+            return Counter(skipped=1)
 
     doc.open()
 

--- a/Exporter.py
+++ b/Exporter.py
@@ -17,6 +17,9 @@ import os
 # probably change it back so you're not spamming the pointless attr change every time
 update_existing_file_times = False
 
+# Older versions of this script used '_' as seperator but Fusion 360 uses ' ' per default in manual exports.
+VERSION_SEPARATOR = '_' # use either ' ' or '_'
+
 log_file = None
 log_fh = None
 
@@ -213,12 +216,12 @@ def visit_sketches(ctx: Ctx, doc: LazyDocument, component):
 
 def export_filename(ctx: Ctx, format: Format, file: adsk.core.DataFile):
     sanitized = sanitize_filename(file.name)
-    name = f'{sanitized} v{file.versionNumber}.{format.value}'
+    name = f'{sanitized}{VERSION_SEPARATOR}v{file.versionNumber}.{format.value}'
     return ctx.folder / name
 
 def export_archive_filename(ctx: Ctx, format: Format, archive_extension, file):
     sanitized = sanitize_filename(file.name)
-    name = f'{sanitized} v{file.versionNumber}.{format.value}.{archive_extension}'
+    name = f'{sanitized}{VERSION_SEPARATOR}v{file.versionNumber}.{format.value}.{archive_extension}'
     return ctx.folder / name
 
 def export_file(ctx: Ctx, format: Format, doc: LazyDocument) -> Counter:
@@ -269,7 +272,7 @@ def export_file(ctx: Ctx, format: Format, doc: LazyDocument) -> Counter:
     return Counter(saved=1)
 
 def visit_file(ctx: Ctx, file: adsk.core.DataFile) -> Counter:
-    log(f'Visiting file {file.name} v{file.versionNumber} . {file.fileExtension}')
+    log(f'Visiting file {file.name}{VERSION_SEPARATOR}v{file.versionNumber} . {file.fileExtension}')
 
     if file.fileExtension != 'f3d':
         log(f'file {file.name} has extension {file.fileExtension} which is not currently handled, skipping')

--- a/Exporter.py
+++ b/Exporter.py
@@ -56,7 +56,7 @@ FormatFromName = {x.value: x for x in Format}
 
 DEFAULT_SELECTED_FORMATS = {Format.F3D, Format.STEP}
 
-archive_extensions = ['.zip', '.gz', '.tar.gz', '.tar.bz2', '.tar.xz']
+archive_extensions = ['.zip', '.rar', '.gz', '.tar.gz', '.tar.bz2', '.tar.xz']
 
 class Ctx(NamedTuple):
     app: adsk.core.Application

--- a/Exporter.py
+++ b/Exporter.py
@@ -56,7 +56,7 @@ FormatFromName = {x.value: x for x in Format}
 
 DEFAULT_SELECTED_FORMATS = {Format.F3D, Format.STEP}
 
-archive_extensions = ['zip', 'gz', 'tar.gz', 'tar.bz2', 'tar.xz']
+archive_extensions = ['.zip', '.gz', '.tar.gz', '.tar.bz2', '.tar.xz']
 
 class Ctx(NamedTuple):
     app: adsk.core.Application
@@ -219,11 +219,6 @@ def export_filename(ctx: Ctx, format: Format, file: adsk.core.DataFile):
     name = f'{sanitized}{VERSION_SEPARATOR}v{file.versionNumber}.{format.value}'
     return ctx.folder / name
 
-def export_archive_filename(ctx: Ctx, format: Format, archive_extension, file):
-    sanitized = sanitize_filename(file.name)
-    name = f'{sanitized}{VERSION_SEPARATOR}v{file.versionNumber}.{format.value}.{archive_extension}'
-    return ctx.folder / name
-
 def export_file(ctx: Ctx, format: Format, doc: LazyDocument) -> Counter:
     output_path = export_filename(ctx, format, doc.file)
     if output_path.exists():
@@ -232,7 +227,7 @@ def export_file(ctx: Ctx, format: Format, doc: LazyDocument) -> Counter:
         log(f'{output_path} already exists, skipping')
         return Counter(skipped=1)
     for archive_extension in archive_extensions:
-        archive_path = export_archive_filename(ctx, format, archive_extension, doc.file)
+        archive_path = output_path.with_name(output_path.name + archive_extension)
         if archive_path.exists():
             log(f'{output_path} already exists as archive, skipping')
             return Counter(skipped=1)

--- a/Exporter.py
+++ b/Exporter.py
@@ -267,7 +267,7 @@ def export_file(ctx: Ctx, format: Format, doc: LazyDocument) -> Counter:
     return Counter(saved=1)
 
 def visit_file(ctx: Ctx, file: adsk.core.DataFile) -> Counter:
-    log(f'Visiting file {file.name}{VERSION_SEPARATOR}v{file.versionNumber} . {file.fileExtension}')
+    log(f'Visiting file {file.name}{VERSION_SEPARATOR}v{file.versionNumber}.{file.fileExtension}')
 
     if file.fileExtension != 'f3d':
         log(f'file {file.name} has extension {file.fileExtension} which is not currently handled, skipping')

--- a/Exporter.py
+++ b/Exporter.py
@@ -184,16 +184,35 @@ def set_mtime(path: Path, time: int):
     """utime wants to set atime and mtime, we just set it the same"""
     os.utime(path, (time, time))
 
+def output_path_exists(path: Path, doc: LazyDocument) -> bool:
+    """
+    Check if the file path already exists with version extension.
+    Also checks for archived versions of the files to export and if update_existing_file_times
+    is set, updates the mtime of existing files (not the archives).
+    """
+    if path.exists():
+        if update_existing_file_times:
+            set_mtime(path, doc.file.dateModified)
+            log(f'{path} already exists, but mtime was corrected')
+        else:
+            log(f'{path} already exists, skipping')
+        return True
+
+    for archive_extension in archive_extensions:
+        archive_path = path.with_name(path.name + archive_extension)
+        if archive_path.exists():
+            log(f'{path} already exists as archive, skipping')
+            return True
+
+    return False
+
 # component: adsk.core.Component but that doesn't exist for some reason?
 # sketch   : adsk.core.Sketch likewise
 def export_sketch(ctx: Ctx, doc: LazyDocument, component, sketch):
     output_path = ctx.folder / f'{sanitize_filename(sketch.name)}.dxf'
-    if output_path.exists():
-        if update_existing_file_times:
-            set_mtime(output_path, doc.file.dateModified)
-        log(f'{output_path} already exists, skipping')
+    if output_path_exists(output_path, doc):
         return Counter(skipped=1)
-    
+
     log(f'Exporting sketch {sketch.name} in {component.name} to {output_path}')
     output_path.parent.mkdir(exist_ok=True, parents=True)
     sketch.saveAsDXF(str(output_path))
@@ -221,16 +240,8 @@ def export_filename(ctx: Ctx, format: Format, file: adsk.core.DataFile):
 
 def export_file(ctx: Ctx, format: Format, doc: LazyDocument) -> Counter:
     output_path = export_filename(ctx, format, doc.file)
-    if output_path.exists():
-        if update_existing_file_times:
-            set_mtime(output_path, doc.file.dateModified)
-        log(f'{output_path} already exists, skipping')
+    if output_path_exists(output_path, doc):
         return Counter(skipped=1)
-    for archive_extension in archive_extensions:
-        archive_path = output_path.with_name(output_path.name + archive_extension)
-        if archive_path.exists():
-            log(f'{output_path} already exists as archive, skipping')
-            return Counter(skipped=1)
 
     doc.open()
 
@@ -267,7 +278,7 @@ def export_file(ctx: Ctx, format: Format, doc: LazyDocument) -> Counter:
     return Counter(saved=1)
 
 def visit_file(ctx: Ctx, file: adsk.core.DataFile) -> Counter:
-    log(f'Visiting file {file.name}{VERSION_SEPARATOR}v{file.versionNumber}.{file.fileExtension}')
+    log(f'Visiting file {file.name} v{file.versionNumber}.{file.fileExtension}')
 
     if file.fileExtension != 'f3d':
         log(f'file {file.name} has extension {file.fileExtension} which is not currently handled, skipping')

--- a/Exporter.py
+++ b/Exporter.py
@@ -18,7 +18,7 @@ import os
 update_existing_file_times = False
 
 # Older versions of this script used '_' as seperator but Fusion 360 uses ' ' per default in manual exports.
-VERSION_SEPARATOR = ' ' # use either ' ' or '_'
+VERSION_SEPARATOR = '_' # use either ' ' or '_'
 
 log_file = None
 log_fh = None


### PR DESCRIPTION
If I export the files manually on Windows, Fusion 360 is naming the version with a space and not `_`. For this reason I changed the _ to a space to make it compatible with already exported files.

Also I compressed a lot of my older files (even tough I realized later that most of the file types already are) and to not export them again I implemented a extension check in the filenames to skip them if a compressed version already exists.

Both changes where only made to make it more compatible with my own setup and might be not really interesting for existing users. Maybe adding checkboxes for those settings would be a solution? Also if the settings could be stored somewhere for the next run would be really nice, but I don't know how to do that. 🤷‍♂️ 