### PR TITLE
Adds support for exporting non-design files

### DIFF
--- a/Exporter.manifest
+++ b/Exporter.manifest
@@ -6,6 +6,6 @@
     "description": {
         "": "Export files from projects"
     },
-    "version": "20241203.1",
+    "version": "20250110.1",
     "supportedOS": "windows|mac"
 }

--- a/Exporter.py
+++ b/Exporter.py
@@ -302,6 +302,7 @@ def visit_file(ctx: Ctx, file: adsk.core.DataFile) -> Counter:
     if file.fileExtension != 'f3d':
         if not ctx.export_non_design_files:
             log(f'Skipping non-design file {file.name} with extension {file.fileExtension}')
+            counter.skipped += 1
             return counter
 
         log(f'file {file.name} has extension {file.fileExtension} attempting direct download')
@@ -309,7 +310,8 @@ def visit_file(ctx: Ctx, file: adsk.core.DataFile) -> Counter:
         try:
             output_path = ctx.folder / f'{sanitize_filename(file.name)}.{file.fileExtension}'
             if output_path_exists(output_path, LazyDocument(ctx, file)):
-                return Counter(skipped=1)
+                counter.skipped += 1
+                return counter
 
             output_path.parent.mkdir(exist_ok=True, parents=True)
 

--- a/Exporter.py
+++ b/Exporter.py
@@ -79,6 +79,7 @@ class Ctx(NamedTuple):
     unhide_all: bool
     save_sketches: bool
     num_versions: int # -1 means all versions
+    export_non_design_files: bool
 
     def extend(self, other):
         return self._replace(folder=self.folder / other)
@@ -296,12 +297,35 @@ def export_file(ctx: Ctx, format: Format, doc: LazyDocument) -> Counter:
 def visit_file(ctx: Ctx, file: adsk.core.DataFile) -> Counter:
     log(f'Visiting file {file.name} v{file.versionNumber}.{file.fileExtension}')
 
+    counter = Counter()
+
     if file.fileExtension != 'f3d':
-        log(f'file {file.name} has extension {file.fileExtension} which is not currently handled, skipping')
-        return Counter(skipped=1)
+        if not ctx.export_non_design_files:
+            log(f'Skipping non-design file {file.name} with extension {file.fileExtension}')
+            return counter
+
+        log(f'file {file.name} has extension {file.fileExtension} attempting direct download')
+
+        try:
+            output_path = ctx.folder / f'{sanitize_filename(file.name)}.{file.fileExtension}'
+            if output_path_exists(output_path, LazyDocument(ctx, file)):
+                return Counter(skipped=1)
+
+            output_path.parent.mkdir(exist_ok=True, parents=True)
+
+            file.download(str(output_path), None)  # Synchronous download
+
+            set_mtime(output_path, file.dateModified)
+            log(f'Saved {output_path}')
+            counter.saved += 1
+
+        except Exception:
+            counter.errored += 1
+            log(traceback.format_exc())
+
+        return counter
 
     with LazyDocument(ctx, file) as doc:
-        counter = Counter()
 
         if ctx.save_sketches:
             doc.open()
@@ -314,7 +338,7 @@ def visit_file(ctx: Ctx, file: adsk.core.DataFile) -> Counter:
                 counter.errored += 1
                 log(traceback.format_exc())
 
-        return counter
+    return counter
 
 def file_versions(file: adsk.core.DataFile, num_versions):
     # file.versions (should) start with the current/latest version
@@ -406,6 +430,7 @@ class I(StrEnum):
     all_versions = 'all_versions'
     save_sketches = 'save_sketches'
     version_separator_is_space = 'version_separator_is_space'
+    export_non_design_files = 'export_non_design_files'
 
 def populate_data_projects_list(dropdown, show_folders=False, selected=None):
     app = adsk.core.Application.get()
@@ -488,6 +513,9 @@ class ExporterCommandCreatedEventHandler(adsk.core.CommandCreatedEventHandler):
 
             version_separator_is_space = last_settings.get(I.version_separator_is_space, VERSION_SEPARATOR == ' ')
             inputs.addBoolValueInput(I.version_separator_is_space, 'Version Separator is Space', True, '', version_separator_is_space)
+
+            export_non_design_files = last_settings.get(I.export_non_design_files, False)
+            inputs.addBoolValueInput(I.export_non_design_files, 'Export Non-Design Files', True, '', export_non_design_files)
         except:
             message_box_traceback()
 
@@ -557,6 +585,7 @@ class ExporterCommandExecuteHandler(adsk.core.CommandEventHandler):
                 I.version_count: iv(I.version_count),
                 I.all_versions: iv(I.all_versions),
                 I.version_separator_is_space: iv(I.version_separator_is_space),
+                I.export_non_design_files: iv(I.export_non_design_files),
             })
 
             # kinda hacky
@@ -572,6 +601,7 @@ class ExporterCommandExecuteHandler(adsk.core.CommandEventHandler):
                 unhide_all = iv(I.unhide_all),
                 save_sketches = iv(I.save_sketches),
                 num_versions = -1 if iv(I.all_versions) else iv(I.version_count),
+                export_non_design_files = iv(I.export_non_design_files),
             )
             run_main(ctx)
         except:

--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ or see the [offical docs](https://www.autodesk.com/support/technical/article/caa
 5) Export Sketches as DXF: Each sketch will get exported as dxf
 6) Versions: Control how many versions are exported. See [Versions](#Versions)
 7) Version Separator Is Space: Controls which character `_` or ` ` (space) is used between the name and version (ie. `name_v42.stl` or `name v42.stl`). Defaults to the original `_` and checking this will use ` ` (space) to better match Fusion.
+8) Export Non-Design Files: If true, all [non-design files](https://help.autodesk.com/view/PLM/ENU/?guid=UG-ATTTAB-ATTACHMENTS) will be exported.
 
 The last run's settings are loaded by default (if they exist). They are stored next to the `Exporter.py` file on your file system in a file called `last_settings.json`. In "My Scripts", you can right-click "Exporter" and then "Open file location" to get there. If you rename projects or folders you will have to reselect those projects.
 

--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ or see the [offical docs](https://www.autodesk.com/support/technical/article/caa
 5) Export Sketches as DXF: Each sketch will get exported as dxf
 6) Versions: Control how many versions are exported. See [Versions](#Versions)
 7) Version Separator Is Space: Controls which character `_` or ` ` (space) is used between the name and version (ie. `name_v42.stl` or `name v42.stl`). Defaults to the original `_` and checking this will use ` ` (space) to better match Fusion.
-8) Export Non-Design Files: If true, all [non-design files](https://help.autodesk.com/view/PLM/ENU/?guid=UG-ATTTAB-ATTACHMENTS) will be exported.
+8) Export Non-Design Files: If true, all [non-design files](https://help.autodesk.com/view/PLM/ENU/?guid=UG-ATTTAB-ATTACHMENTS) will be exported. Note that only the latest version will be exported and the version number will not be appended. 
 
 The last run's settings are loaded by default (if they exist). They are stored next to the `Exporter.py` file on your file system in a file called `last_settings.json`. In "My Scripts", you can right-click "Exporter" and then "Open file location" to get there. If you rename projects or folders you will have to reselect those projects.
 
@@ -90,3 +90,4 @@ You might run into an issue with the `VERSION_SEPARATOR` (whether it is export `
 * Problematic `"` in project names reported by TheShanMan
 * Installation doc improvement reported by sqlBender
 * Version ordering bug reported and diagnosed by loglow
+* Non-design file support added by [raphael-bmec-co](https://github.com/raphael-bmec-co)


### PR DESCRIPTION
Adds a checkbox to enable exporting of non-design files - see [here](https://help.autodesk.com/view/PLM/ENU/?guid=UG-ATTTAB-ATTACHMENTS) for supported types.
<img width=300 src="https://github.com/user-attachments/assets/23cbf863-ca9b-4d8d-ac92-47e628ff7ea6">
