### PR TITLE
Fix Python syntax error (else if -> elif)

### DIFF
--- a/Exporter.py
+++ b/Exporter.py
@@ -379,7 +379,7 @@ def visit_file(ctx: Ctx, file: adsk.core.DataFile) -> Counter:
                 counter.errored += 1
                 log(traceback.format_exc())
 
-        else if file.fileExtension == 'f3d':
+        elif file.fileExtension == 'f3d':
             for format in ctx.formats:
                 if format != Format.PDF:
                     try:


### PR DESCRIPTION
Python does not support `else if`; this caused a syntax error and prevented the script from running.
Autodesk Fusion reports the following error in the Text Commands window:
```
expected ':' (Exporter.py, line 382)
```